### PR TITLE
Fix async extensions to be run on MainActor

### DIFF
--- a/Sources/XCoordinator/BaseCoordinator.swift
+++ b/Sources/XCoordinator/BaseCoordinator.swift
@@ -193,7 +193,7 @@ extension BaseCoordinator {
     ///         The closure to be called whenever the transition completes.
     ///         Hint: Might be called multiple times but only once per performing the transition.
     ///
-    open func registerInteractiveTransition<GestureRecognizer: UIGestureRecognizer>(
+    public func registerInteractiveTransition<GestureRecognizer: UIGestureRecognizer>(
         for route: RouteType,
         triggeredBy recognizer: GestureRecognizer,
         handler: @escaping (_ handlerRecognizer: GestureRecognizer, _ transition: () -> TransitionAnimation?) -> Void,
@@ -238,7 +238,7 @@ extension BaseCoordinator {
     ///         The closure to be called whenever the transition completes.
     ///         Hint: Might be called multiple times but only once per performing the transition.
     ///
-    open func registerInteractiveTransition<GestureRecognizer: UIGestureRecognizer>(
+    public func registerInteractiveTransition<GestureRecognizer: UIGestureRecognizer>(
         for route: RouteType,
         triggeredBy recognizer: GestureRecognizer,
         progress: @escaping (GestureRecognizer) -> CGFloat,
@@ -287,7 +287,7 @@ extension BaseCoordinator {
     ///     The recognizer to unregister interactive transitions for.
     ///     This method will unregister all interactive transitions with that gesture recognizer.
     ///
-    open func unregisterInteractiveTransitions(triggeredBy recognizer: UIGestureRecognizer) {
+    public func unregisterInteractiveTransitions(triggeredBy recognizer: UIGestureRecognizer) {
         gestureRecognizerTargets.removeAll { target in
             guard target.gestureRecognizer === recognizer else { return false }
             recognizer.removeTarget(target, action: nil)

--- a/Sources/XCoordinator/NavigationAnimationDelegate.swift
+++ b/Sources/XCoordinator/NavigationAnimationDelegate.swift
@@ -263,7 +263,7 @@ extension NavigationAnimationDelegate: UIGestureRecognizerDelegate {
     ///
     /// - Parameter navigationController: The navigation controller to be set up.
     ///
-    open func setupPopGestureRecognizer(for navigationController: UINavigationController) {
+    public func setupPopGestureRecognizer(for navigationController: UINavigationController) {
         self.navigationController = navigationController
         guard let popRecognizer = navigationController.interactivePopGestureRecognizer,
             popRecognizer.delegate !== self else {

--- a/Sources/XCoordinator/Router.swift
+++ b/Sources/XCoordinator/Router.swift
@@ -127,7 +127,7 @@ extension Router {
     /// - Parameters:
     ///     - route: The route to be triggered.
     ///
-    public func trigger(_ route: RouteType) async {
+    @MainActor public func trigger(_ route: RouteType) async {
         await trigger(route, with: .default)
     }
 
@@ -138,7 +138,7 @@ extension Router {
     ///     - route: The route to be triggered.
     ///     - options: Transition options for performing the transition, e.g. whether it should be animated.
     ///
-    public func trigger(_ route: RouteType, with options: TransitionOptions) async {
+    @MainActor public func trigger(_ route: RouteType, with options: TransitionOptions) async {
         _ = await contextTrigger(route, with: options)
     }
 
@@ -159,7 +159,7 @@ extension Router {
     ///     The transition context of the performed transition(s).
     ///     If the context is not needed, use `trigger` instead.
     ///
-    public func contextTrigger(_ route: RouteType, with options: TransitionOptions) async -> TransitionContext {
+    @MainActor public func contextTrigger(_ route: RouteType, with options: TransitionOptions) async -> TransitionContext {
         await withCheckedContinuation { continuation in
             contextTrigger(route, with: options) { context in
                 continuation.resume(returning: context)


### PR DESCRIPTION
Planned for 2.2.1

Changelog:
- Mark async extensions as MainActor since they need to be run from MainActor
- Mark non-objc open functions in extensions to be public due to Xcode warnings
